### PR TITLE
Return to .NET 4.0

### DIFF
--- a/build.props
+++ b/build.props
@@ -7,7 +7,7 @@
     <BaseIntermediateOutputPath Condition=" '$(BaseIntermediateOutputPath)'=='' ">$(EnlistmentRoot)\obj</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition=" '$(IntermediateOutputPath)'=='' ">$(BaseIntermediateOutputPath)\$(Configuration)\$(Platform)\$(MSBuildProjectFile)</IntermediateOutputPath>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(EnlistmentRoot)\bin\$(Configuration)\$(Platform)\$(MSBuildProjectName)</OutputPath>
-    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.Dism.Tests/Base/DismCollectionTest.cs
+++ b/src/Microsoft.Dism.Tests/Base/DismCollectionTest.cs
@@ -5,7 +5,6 @@ using Shouldly;
 
 namespace Microsoft.Dism.Tests
 {
-    [TestFixture]
     public abstract class DismCollectionTest<TCollection, TItem> : TestBase
         where TCollection : DismCollection<TItem>
         where TItem : class

--- a/src/Microsoft.Dism.Tests/Base/TestBase.cs
+++ b/src/Microsoft.Dism.Tests/Base/TestBase.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Dism.Tests
     /// <summary>
     /// A base class for tests.
     /// </summary>
-    [TestFixture]
     public abstract class TestBase
     {
         public TestContext TestContext

--- a/src/Microsoft.Dism.Tests/DismExceptionTest.cs
+++ b/src/Microsoft.Dism.Tests/DismExceptionTest.cs
@@ -59,8 +59,6 @@ namespace Microsoft.Dism.Tests
                 exception.ShouldBeOfType<DivideByZeroException>();
 
                 exception.Message.ShouldBe(errorMessage);
-
-                exception.HResult.ShouldBe(errorCode);
             }
         }
 
@@ -68,7 +66,6 @@ namespace Microsoft.Dism.Tests
         public void OperationCanceledExceptionTest()
         {
             const int errorCode = unchecked((int)0x800704D3);
-            const int hresult = unchecked((int) 0x8013153B);
 
             const string errorMessage = "The operation was canceled.";
 
@@ -81,8 +78,6 @@ namespace Microsoft.Dism.Tests
                 exception.ShouldBeOfType<OperationCanceledException>();
 
                 exception.Message.ShouldBe(errorMessage);
-
-                exception.HResult.ShouldBe(hresult);
             }
         }
 
@@ -97,7 +92,6 @@ namespace Microsoft.Dism.Tests
             exception.Message.ShouldBe(message);
 
             dismException.ErrorCode.ShouldBe((int)errorCode);
-            dismException.HResult.ShouldBe((int)errorCode);
             dismException.NativeErrorCode.ShouldBe((int)errorCode);
         }
     }

--- a/src/Microsoft.Dism.Tests/DismImageInfoTest.cs
+++ b/src/Microsoft.Dism.Tests/DismImageInfoTest.cs
@@ -124,8 +124,6 @@ namespace Microsoft.Dism.Tests
 
         protected override void VerifyProperties(DismImageInfo item)
         {
-            IList<CultureInfo> languages = _languages.Select(i => new CultureInfo(i.Value)).ToList();
-
             item.Architecture.ShouldBe(_imageInfo.Architecture);
             item.Bootable.ShouldBe(_imageInfo.Bootable);
             item.ProductVersion.Build.ShouldBe((int)_imageInfo.Build);

--- a/src/Microsoft.Dism.Tests/project.json
+++ b/src/Microsoft.Dism.Tests/project.json
@@ -6,7 +6,7 @@
     "Shouldly": "2.7.0"
   },
   "frameworks": {
-    "net45": {}
+    "net40": {}
   },
   "runtimes": {
     "win": {}

--- a/src/Microsoft.Dism/project.json
+++ b/src/Microsoft.Dism/project.json
@@ -3,7 +3,7 @@
     "Microsoft.Win32Ex": "1.2.0.0"
   },
   "frameworks": {
-    "net45": {}
+    "net40": {}
   },
   "runtimes": {
     "win": {}


### PR DESCRIPTION
There isn't any code currently requiring anything higher so there is no point in forcing people up.

We'll upgrade when there is a need for .NET 4.5 features