### PR TITLE
Add external DISM generations support. Fixes #5 & #25.

### DIFF
--- a/src/Microsoft.Dism/DismApi.cs
+++ b/src/Microsoft.Dism/DismApi.cs
@@ -1267,10 +1267,10 @@ namespace Microsoft.Dism
         /// <returns></returns>
         public static void Shutdown()
         {
-            if (DismGenerationInitialized != DismGeneration.NotFound)
+            if (CurrentDismGeneration != DismGeneration.NotFound)
             {
                 DismUtilities.UnloadDismGenerationLibrary();
-                DismGenerationInitialized = DismGeneration.NotFound;
+                CurrentDismGeneration = DismGeneration.NotFound;
             }
 
             ThrowIfFail(NativeMethods.DismShutdown);

--- a/src/Microsoft.Dism/DismApi.cs
+++ b/src/Microsoft.Dism/DismApi.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Win32;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,15 +11,6 @@ namespace Microsoft.Dism
     /// </summary>
     public static partial class DismApi
     {
-        #region Properties
-
-        /// <summary>
-        /// Represents the DISM Generational Library initialized for use with the DismApi Wrapper (via InitializeEx()). Returns the specific DismGeneration in use; otherwise, returns DismGeneration.NotFound.
-        /// </summary>
-        private static DismGeneration DismGenerationInitialized { get; set; } = DismGeneration.NotFound;
-
-        #endregion
-
         /// <summary>
         /// Add a capability to an image.
         /// </summary>
@@ -844,64 +834,6 @@ namespace Microsoft.Dism
         public static void Initialize(DismLogLevel logLevel, string logFilePath, string scratchDirectory)
         {
             ThrowIfFail(() => NativeMethods.DismInitialize(logLevel, logFilePath, scratchDirectory));
-        }
-
-        /// <summary>
-        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
-        /// </summary>
-        /// <param name="logLevel">Indicates the level of logging.</param>
-        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
-        /// <exception cref="DismException">When a failure occurs.</exception>
-        public static void InitializeEx(DismLogLevel logLevel)
-        {
-            InitializeEx(logLevel, String.Empty, String.Empty, DismUtilities.GetLatestDismGeneration());
-        }
-
-        /// <summary>
-        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
-        /// </summary>
-        /// <param name="logLevel">Indicates the level of logging.</param>
-        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
-        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception>  
-        /// <exception cref="DismException">When a failure occurs.</exception>
-        public static void InitializeEx(DismLogLevel logLevel, string logFilePath)
-        {
-            InitializeEx(logLevel, logFilePath, String.Empty, DismUtilities.GetLatestDismGeneration());
-        }
-
-        /// <summary>
-        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
-        /// </summary>
-        /// <param name="logLevel">Indicates the level of logging.</param>
-        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
-        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
-        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
-        /// <exception cref="DismException">When a failure occurs.</exception>
-        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory)
-        {
-            InitializeEx(logLevel, logFilePath, scratchDirectory, DismUtilities.GetLatestDismGeneration());
-        }
-
-        /// <summary>
-        /// Initializes DISM API, using the specified DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
-        /// </summary>
-        /// <param name="logLevel">Indicates the level of logging.</param>
-        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
-        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
-        /// <param name="dismGeneration">The DISM Generational Library to be used.</param>
-        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
-        /// <exception cref="DismException">When a failure occurs.</exception>
-        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory, DismGeneration dismGeneration)
-        {
-            if (DismGenerationInitialized != DismGeneration.NotFound)
-                throw new Exception(String.Format("A DISM Generation library is already loaded ({0}). Please call Shutdown() first to release the existing library.", dismGeneration.ToString()));
-
-            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
-                throw new Exception(String.Format("Loading the latest DISM Generation library ({0}) failed.", dismGeneration.ToString()));
-
-            DismGenerationInitialized = dismGeneration;
-
-            DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
         }
 
         /// <summary>

--- a/src/Microsoft.Dism/DismApi.cs
+++ b/src/Microsoft.Dism/DismApi.cs
@@ -12,6 +12,28 @@ namespace Microsoft.Dism
     /// </summary>
     public static partial class DismApi
     {
+        #region Properties
+
+        private static DismGeneration dismGenerationInitialized;
+
+        /// <summary>
+        /// Represents the DISM Generational Library initialized for use with the DismApi Wrapper (via InitializeEx()). Returns the specific DismGeneration in use; otherwise, returns DismGeneration.NotFound.
+        /// </summary>
+        public static DismGeneration DismGenerationInitialized
+        {
+            get
+            {
+                return DismGenerationInitialized;
+            }
+
+            private set
+            {
+                dismGenerationInitialized = value;
+            }
+        }
+
+        #endregion
+
         /// <summary>
         /// Add a capability to an image.
         /// </summary>
@@ -811,6 +833,8 @@ namespace Microsoft.Dism
         /// <exception cref="DismException">When a failure occurs.</exception>
         public static void Initialize(DismLogLevel logLevel)
         {
+            DismGenerationInitialized = DismGeneration.NotFound;
+
             DismApi.Initialize(logLevel, null);
         }
 
@@ -822,6 +846,8 @@ namespace Microsoft.Dism
         /// <exception cref="DismException">When a failure occurs.</exception>
         public static void Initialize(DismLogLevel logLevel, string logFilePath)
         {
+            DismGenerationInitialized = DismGeneration.NotFound;
+
             DismApi.Initialize(logLevel, logFilePath, null);
         }
 
@@ -834,7 +860,85 @@ namespace Microsoft.Dism
         /// <exception cref="DismException">When a failure occurs.</exception>
         public static void Initialize(DismLogLevel logLevel, string logFilePath, string scratchDirectory)
         {
+            DismGenerationInitialized = DismGeneration.NotFound;
+
             ThrowIfFail(() => NativeMethods.DismInitialize(logLevel, logFilePath, scratchDirectory));
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel)
+        {
+            DismGeneration dismGeneration = DismUtilities.GetLatestDismGeneration();
+
+            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
+                throw new Exception(String.Format("Loading the latest DISM Generation Library ({0}) failed.", dismGeneration.ToString()));
+
+            DismGenerationInitialized = dismGeneration;
+
+            DismApi.Initialize(logLevel);
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception>  
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath)
+        {
+            DismGeneration dismGeneration = DismUtilities.GetLatestDismGeneration();
+
+            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
+                throw new Exception(String.Format("Loading the latest DISM Generation Library ({0}) failed.", dismGeneration.ToString()));
+
+            DismGenerationInitialized = dismGeneration;
+
+            DismApi.Initialize(logLevel, logFilePath);
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
+        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory)
+        {
+            DismGeneration dismGeneration = DismUtilities.GetLatestDismGeneration();
+
+            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
+                throw new Exception(String.Format("Loading the latest DISM Generation Library ({0}) failed.", dismGeneration.ToString()));
+
+            DismGenerationInitialized = dismGeneration;
+
+            DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the specified DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
+        /// <param name="dismGeneration">The DISM Generational Library to be used.</param>
+        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory, DismGeneration dismGeneration)
+        {
+            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
+                throw new Exception(String.Format("Loading the latest DISM Generation Library ({0}) failed.", dismGeneration.ToString()));
+
+            DismGenerationInitialized = dismGeneration;
+
+            DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
         }
 
         /// <summary>
@@ -1268,6 +1372,12 @@ namespace Microsoft.Dism
         /// <returns></returns>
         public static void Shutdown()
         {
+            if (DismGenerationInitialized != DismGeneration.NotFound)
+            {
+                DismUtilities.UnloadDismGenerationLibrary();
+                dismGenerationInitialized = DismGeneration.NotFound;
+            }
+
             ThrowIfFail(NativeMethods.DismShutdown);
         }
 

--- a/src/Microsoft.Dism/DismApiEx.cs
+++ b/src/Microsoft.Dism/DismApiEx.cs
@@ -57,14 +57,18 @@ namespace Microsoft.Dism
         public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory, DismGeneration dismGeneration)
         {
             if (CurrentDismGeneration != DismGeneration.NotFound)
-                throw new Exception(String.Format("A DISM Generation library is already loaded ({0}). Please call Shutdown() first to release the existing library.", dismGeneration.ToString()));
+            {
+                throw new Exception($"A DISM Generation library is already loaded ({dismGeneration}). Please call Shutdown() first to release the existing library.");
+            }
 
             if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
-                throw new Exception(String.Format("Loading the latest DISM Generation library ({0}) failed.", dismGeneration.ToString()));
-
-            CurrentDismGeneration = dismGeneration;
+            {
+                throw new Exception($"Loading the latest DISM Generation library ({dismGeneration}) failed.");
+            }
 
             DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
+
+            CurrentDismGeneration = dismGeneration;
         }
     }
 }

--- a/src/Microsoft.Dism/DismApiEx.cs
+++ b/src/Microsoft.Dism/DismApiEx.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Dism
         /// <summary>
         /// Represents the DISM Generational Library initialized for use with the DismApi Wrapper (via InitializeEx()). Returns the specific DismGeneration in use; otherwise, returns DismGeneration.NotFound.
         /// </summary>
-        private static DismGeneration DismGenerationInitialized { get; set; } = DismGeneration.NotFound;
+        private static DismGeneration CurrentDismGeneration { get; set; } = DismGeneration.NotFound;
 
         /// <summary>
         /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
@@ -56,13 +56,13 @@ namespace Microsoft.Dism
         /// <exception cref="DismException">When a failure occurs.</exception>
         public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory, DismGeneration dismGeneration)
         {
-            if (DismGenerationInitialized != DismGeneration.NotFound)
+            if (CurrentDismGeneration != DismGeneration.NotFound)
                 throw new Exception(String.Format("A DISM Generation library is already loaded ({0}). Please call Shutdown() first to release the existing library.", dismGeneration.ToString()));
 
             if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
                 throw new Exception(String.Format("Loading the latest DISM Generation library ({0}) failed.", dismGeneration.ToString()));
 
-            DismGenerationInitialized = dismGeneration;
+            CurrentDismGeneration = dismGeneration;
 
             DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
         }

--- a/src/Microsoft.Dism/DismApiEx.cs
+++ b/src/Microsoft.Dism/DismApiEx.cs
@@ -1,0 +1,70 @@
+﻿using System;
+
+namespace Microsoft.Dism
+{
+    public static partial class DismApi
+    {
+        /// <summary>
+        /// Represents the DISM Generational Library initialized for use with the DismApi Wrapper (via InitializeEx()). Returns the specific DismGeneration in use; otherwise, returns DismGeneration.NotFound.
+        /// </summary>
+        private static DismGeneration DismGenerationInitialized { get; set; } = DismGeneration.NotFound;
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel)
+        {
+            InitializeEx(logLevel, String.Empty, String.Empty, DismUtilities.GetLatestDismGeneration());
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception>  
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath)
+        {
+            InitializeEx(logLevel, logFilePath, String.Empty, DismUtilities.GetLatestDismGeneration());
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the latest installed DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
+        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory)
+        {
+            InitializeEx(logLevel, logFilePath, scratchDirectory, DismUtilities.GetLatestDismGeneration());
+        }
+
+        /// <summary>
+        /// Initializes DISM API, using the specified DISM Generation. Initialize must be called once per process before calling any other DISM API functions.
+        /// </summary>
+        /// <param name="logLevel">Indicates the level of logging.</param>
+        /// <param name="logFilePath">A relative or absolute path to a log file. All messages generated will be logged to this path. If NULL, the default log path, %windir%\Logs\DISM\dism.log, will be used.</param>
+        /// <param name="scratchDirectory">A relative or absolute path to a scratch directory. DISM API will use this directory for internal operations. If null, the default temp directory, \Windows\%Temp%, will be used.</param>
+        /// <param name="dismGeneration">The DISM Generational Library to be used.</param>
+        /// /// <exception cref="Exception">If an error occurs loading the latest DISM Generational Library.</exception> 
+        /// <exception cref="DismException">When a failure occurs.</exception>
+        public static void InitializeEx(DismLogLevel logLevel, string logFilePath, string scratchDirectory, DismGeneration dismGeneration)
+        {
+            if (DismGenerationInitialized != DismGeneration.NotFound)
+                throw new Exception(String.Format("A DISM Generation library is already loaded ({0}). Please call Shutdown() first to release the existing library.", dismGeneration.ToString()));
+
+            if (dismGeneration != DismGeneration.NotFound && !DismUtilities.LoadDismGenerationLibrary(dismGeneration))
+                throw new Exception(String.Format("Loading the latest DISM Generation library ({0}) failed.", dismGeneration.ToString()));
+
+            DismGenerationInitialized = dismGeneration;
+
+            DismApi.Initialize(logLevel, logFilePath, scratchDirectory);
+        }
+    }
+}

--- a/src/Microsoft.Dism/DismUtilities.cs
+++ b/src/Microsoft.Dism/DismUtilities.cs
@@ -1,4 +1,4 @@
-﻿///
+﻿/*
 /// OVERVIEW:
 /// 
 /// This class was written to hold non-DISM-specific data structures that are useful to a DISM API user, but do not neatly fit
@@ -52,7 +52,7 @@
 /// 4.  In this fashion, one could load DISM from WADK 10, unload it, load DISM from WAIK, unload it, load DISM from the System, etc.
 /// 
 /// 5.  This method of loading/unloading DISM generation libraries supports ANYCPU, X86, and AMD64, and also supports the CLR "Prefer 32-bit" setting.
-/// 
+*/
 
 using Microsoft.Win32;
 using System;

--- a/src/Microsoft.Dism/DismUtilities.cs
+++ b/src/Microsoft.Dism/DismUtilities.cs
@@ -1,0 +1,287 @@
+﻿///
+/// OVERVIEW:
+/// 
+/// This class was written to hold non-DISM-specific data structures that are useful to a DISM API user, but do not neatly fit
+/// into the managed, wrapped classes.
+/// 
+/// USAGE AND NOTES:
+/// 
+/// The standard usage of the DismApi begins with "DismApi.Initialize()" and ends with "DismApi.Shutdown()", wrapping the same standard functionality 
+/// of the Microsoft DISM C library. However, this functionality is limited to the (local) version of dismapi.dll, located (in most cases) in \System32.
+/// 
+/// DISM has not always been built-in to Windows, however, and is also provided (as part of a stand-alone tool package) known as "Windows Assessment and Installation Kit" 
+/// (or "WAIK", Windows 7 era), and now as "Windows Assessment and Deployment Kit" (or "WADK", Windows 8.0 - now.)
+/// 
+/// Users install WADK (and/or WAIK) tools to include standard Windows PE images, DISM tools, and other Windows management tooling.
+/// 
+/// In servicing images (online or .WIM), the built-in version of DISM (if even available) may not be able to service different version(s) of images.
+/// For example, as of the Windows 10 Fall Creator's Update (DISM 10.0.16299.15), the built-in version of DISM cannot open a session against a Windows PE 4.0 image (based on Windows 8.0.)
+/// I presume the same is true of Windows PE 5.0 (based on Windows 8.1.) Thus, in order to service different versions of images, the tooling of DISM from WADK/WAIK is necessary.
+/// (Upon investigation, the DISM libraries included in WADK/WAIK include more libraries than what's included in Windows alone, including downleveling libraries, which are presumably for handling 
+/// older/other versions/architectures, etc.)
+/// 
+/// WITH RESPECT TO DISM TOOLING:
+/// 
+/// 1.  Microsoft was calling the toolset "Windows Assessment and Installation Kit" as of Windows 7, but now calls it the "Windows Assessment and Deployment Kit" (starting with 8.0 and continuing on.)
+/// 
+/// 2.  WAIK (Windows 7) can be installed to provide Windows PE 3.0 (and DISM servicing), OR WAIK Service Pack 1 can be installed for Windows PE 3.1 (and DISM servicing), but both cannot be
+///     installed at the same time.
+///     
+/// 3.  WADK (Windows 8.0) can be installed to provide support for Windows PE 4.0 (and DISM servicing), OR WADK (Windows 8.1) can be installed for Windows PE 5.0 (and DISM servicing), but both
+///     cannot be installed at the same time.
+///     
+/// 4.  Only one version of WADK (Windows 10.x) can be installed to provide support for Windows PE 10 (and DISM servicing) at the same time.
+/// 
+/// 5.  Thus, a user could potentially have WAIK 3.0 or 3.1 installed, WADK 4.0 or 5.0 installed, and WADK 10 installed, all at the same time. In doing so, they could create and service Windows PE images
+///     from Windows 7/7 SP1, 8/8.1, and 10.
+///     
+/// 6.  Regardless of what OS you (or a user) has, it is recommended to install the latest version of the WADK (10.x as of this writing), as the latest tooling should contain support for and be able to service older images.
+///     Therefore, WADK 10.x (and it's DISM libraries) can service images of Windows 7, 8, 8.1, 10.x.
+///     
+/// LOADING A SPECIFIC DISM LIBRARY:
+/// 
+/// 1.  Use the Properties ("WADK10DISMAPIPath") to determine if said version of WADK/WAIK is installed, and if so, where the DISM API libraries are installed. 
+///     "GetLatestDismGeneration()" will search all paths and provide the latest installed version, if available, as an enumeration.
+///     
+/// 2.  Call "LoadDismGenerationLibrary()" BEFORE you call DismApi.Initialize(). This works because we use the native "LoadLibrary()" method to load the specified DISM generational library into the process space,
+///     and when you call "DismApi.Initialize()", the Marshal (via DllImport()) looks in process space first for a loaded module. Upon finding a module that matches the requested one's name, it then loads it 
+///     (and any other associated libraries) as needed.
+///     
+/// 3.  After calling "DismApi.Shutdown()", call "UnloadDismGenerationLibrary()" to remove the loaded DISM library from the process space. 
+/// 
+/// 4.  In this fashion, one could load DISM from WADK 10, unload it, load DISM from WAIK, unload it, load DISM from the System, etc.
+/// 
+/// 5.  This method of loading/unloading DISM generation libraries supports ANYCPU, X86, and AMD64, and also supports the CLR "Prefer 32-bit" setting.
+/// 
+
+using Microsoft.Win32;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Dism
+{
+    public static class DismUtilities
+    {
+        /// <summary>
+        /// Native methods necessary for manually loading and unloading a specific DISM API library.
+        /// </summary>
+        internal static class NativeMethods
+        {
+            [DllImport("kernel32.dll")]
+            public static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string lpFileName);
+
+            [DllImport("kernel32.dll")]
+            public static extern bool FreeLibrary(IntPtr hModule);
+        }
+
+        /// <summary>
+        /// Represents "generational" versions of Deployment Imaging and Servicing Management.
+        /// </summary>
+        public enum DismGeneration
+        {
+            /// <summary>
+            /// DISM libraries associated with WAIK and/or WADK were not found.
+            /// </summary>
+            NotFound = 0,
+
+            /// <summary>
+            /// DISM associated with the Windows 7 or Windows 7 Service Pack 1 version of the Windows Assessment and Installation Kit (WAIK).
+            /// With respect to Windows PE, this would be 3.0 (Windows 7) or 3.1 (Service Pack 1).
+            /// </summary>
+            Win7,
+
+            /// <summary>
+            /// DISM associated with the Windows 8 version of the Windows Assessment and Deployment Kit (WADK).
+            /// With respect to Windows PE, this would be 4.0 (Windows 8.0).
+            /// </summary>
+            Win8,
+
+            /// <summary>
+            /// DISM associated with the Windows 8.1 version of the Windows Assessment and Deployment Kit (WADK).
+            /// With respect to Windows PE, this would be 5.0 (Windows 8.1).
+            /// </summary>
+            Win8_1,
+
+            /// <summary>
+            /// DISM associated with the Windows 10 version of the Windows Assessment and Deployment Kit (WADK).
+            /// With respect to Windows PE, this would be 10.x (Windows 10.x).
+            /// </summary>
+            Win10
+        }
+
+        /// <summary>
+        /// The handle of the loaded DISM generational library.
+        /// </summary>
+        private static IntPtr hDismApi;
+
+        /// <summary>
+        /// If installed, returns the file path of "dism.exe", which is the entry point for the DISM API in the Windows 7 generation of tools (WAIK).
+        /// Otherwise, returns NULL.
+        /// </summary>
+        public static string WAIKDISMAPIPath
+        {
+            get
+            {
+                using (RegistryKey key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default).OpenSubKey("SOFTWARE\\Microsoft\\ComponentStudio\\6.1.7600.16385"))
+                {
+                    if (key?.GetValue("ServicingPath")?.ToString() == null)
+                        return null;
+
+                    string dismPath = Path.Combine(key.GetValue("ServicingPath").ToString(), "dism.exe");
+
+                    return File.Exists(dismPath) ? dismPath : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// If installed, returns the file path of "dismapi.dll", which is the entry point for the DISM API in the Windows 8 generation of tools (WADK).
+        /// Otherwise, returns NULL.
+        /// </summary>
+        public static string WADK80DISMAPIPath
+        {
+            get
+            {
+                using (RegistryKey key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots"))
+                {
+                    if (key?.GetValue("KitsRoot")?.ToString() == null)
+                        return null;
+
+                    string dismPath = Path.Combine(
+                        key.GetValue("KitsRoot").ToString(),
+                        String.Format("Assessment and Deployment Kit\\Deployment Tools\\{0}\\DISM\\dismapi.dll", Environment.Is64BitProcess ? "amd64" : "x86")
+                        );
+
+                    return File.Exists(dismPath) ? dismPath : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// If installed, returns the file path of "dismapi.dll", which is the entry point for the DISM API in the Windows 8.1 generation of tools (WADK).
+        /// Otherwise, returns NULL.
+        /// </summary>
+        public static string WADK81DISMAPIPath
+        {
+            get
+            {
+                using (RegistryKey key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots"))
+                {
+                    if (key?.GetValue("KitsRoot81")?.ToString() == null)
+                        return null;
+
+                    string dismPath = Path.Combine(
+                        key.GetValue("KitsRoot81").ToString(),
+                        String.Format("Assessment and Deployment Kit\\Deployment Tools\\{0}\\DISM\\dismapi.dll", Environment.Is64BitProcess ? "amd64" : "x86")
+                        );
+
+                    return File.Exists(dismPath) ? dismPath : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// If installed, returns the file path of "dismapi.dll", which is the entry point for the DISM API in the Windows 10.x generation of tools (WADK).
+        /// Otherwise, returns NULL.
+        /// </summary>
+        public static string WADK10DISMAPIPath
+        {
+            get
+            {
+                using (RegistryKey key = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey("SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots"))
+                {
+                    if (key?.GetValue("KitsRoot10")?.ToString() == null)
+                        return null;
+
+                    string dismPath = Path.Combine(
+                        key.GetValue("KitsRoot10").ToString(),
+                        String.Format("Assessment and Deployment Kit\\Deployment Tools\\{0}\\DISM\\dismapi.dll", Environment.Is64BitProcess ? "amd64" : "x86")
+                        );
+
+                    return File.Exists(dismPath) ? dismPath : null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns a DismGeneration enumeration indicating the latest DISM generation installed and available on the local system.
+        /// </summary>
+        /// <returns></returns>
+        public static DismGeneration GetLatestDismGeneration()
+        {
+            if (!String.IsNullOrEmpty(WADK10DISMAPIPath))
+                return DismGeneration.Win10;
+            else if (!String.IsNullOrEmpty(WADK81DISMAPIPath))
+                return DismGeneration.Win8_1;
+            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
+                return DismGeneration.Win8;
+            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
+                return DismGeneration.Win7;
+            else
+                return DismGeneration.NotFound;
+        }
+
+        /// <summary>
+        /// Loads the DISM API library associated with the provided DismGeneration. 
+        /// NOTE: This must be called before calling DismApi.Initialize(), as the initialization takes precedence based on Dynamic Link Library loading.
+        /// If a DismGeneration library has already been loaded when initialize() is called, that version of the DISM generation library is utilized. If no DISM API library
+        /// is loaded when initialization is called, it will attempt to load the DISM API installed on the local system (System32), if available.
+        /// Only a single DISM generation library may be loaded at a given time. To switch versions, the caller can use LoadDismGenerationLibrary() and UnloadDismGenerationLibrary()
+        /// to switch between DISM generations (WAIK and/or WADK) and/or what's natively available on the local system (System32).
+        /// </summary>
+        /// <param name="generation">
+        /// The DismGeneration to be loaded.
+        /// </param>
+        /// <returns>
+        /// TRUE if successful, otherwise FALSE.
+        /// </returns>
+        public static bool LoadDismGenerationLibrary(DismGeneration generation)
+        {
+            if (hDismApi != IntPtr.Zero)
+                return false;
+
+            string dismApiPath = string.Empty;
+
+            switch (generation)
+            {
+                case DismGeneration.Win10:
+                    dismApiPath = WADK10DISMAPIPath;
+                    break;
+
+                case DismGeneration.Win8_1:
+                    dismApiPath = WADK81DISMAPIPath;
+                    break;
+
+                case DismGeneration.Win8:
+                    dismApiPath = WADK80DISMAPIPath;
+                    break;
+
+                case DismGeneration.Win7:
+                    dismApiPath = WAIKDISMAPIPath;
+                    break;
+
+                case DismGeneration.NotFound:
+                default:
+                    return false;
+                    break;
+            }
+
+            return ((hDismApi = NativeMethods.LoadLibrary(dismApiPath)) != IntPtr.Zero ? true : false);
+        }
+
+        /// <summary>
+        /// Unloads a previously-loaded DISM generation library.
+        /// </summary>
+        /// <returns>
+        /// TRUE if successful, otherwise FALSE.
+        /// </returns>
+        public static bool UnloadDismGenerationLibrary()
+        {
+            if (hDismApi != IntPtr.Zero)
+                NativeMethods.FreeLibrary(hDismApi);
+
+            return hDismApi == IntPtr.Zero ? true : false;
+        }
+    }
+}

--- a/src/Microsoft.Dism/DismUtilities.cs
+++ b/src/Microsoft.Dism/DismUtilities.cs
@@ -61,7 +61,42 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Dism
 {
-    public static class DismUtilities
+    /// <summary>
+    /// Represents "generational" versions of Deployment Imaging and Servicing Management.
+    /// </summary>
+    public enum DismGeneration
+    {
+        /// <summary>
+        /// DISM libraries associated with WAIK and/or WADK were not found.
+        /// </summary>
+        NotFound = 0,
+
+        /// <summary>
+        /// DISM associated with the Windows 7 or Windows 7 Service Pack 1 version of the Windows Assessment and Installation Kit (WAIK).
+        /// With respect to Windows PE, this would be 3.0 (Windows 7) or 3.1 (Service Pack 1).
+        /// </summary>
+        Win7,
+
+        /// <summary>
+        /// DISM associated with the Windows 8 version of the Windows Assessment and Deployment Kit (WADK).
+        /// With respect to Windows PE, this would be 4.0 (Windows 8.0).
+        /// </summary>
+        Win8,
+
+        /// <summary>
+        /// DISM associated with the Windows 8.1 version of the Windows Assessment and Deployment Kit (WADK).
+        /// With respect to Windows PE, this would be 5.0 (Windows 8.1).
+        /// </summary>
+        Win8_1,
+
+        /// <summary>
+        /// DISM associated with the Windows 10 version of the Windows Assessment and Deployment Kit (WADK).
+        /// With respect to Windows PE, this would be 10.x (Windows 10.x).
+        /// </summary>
+        Win10,
+    }
+
+    internal static class DismUtilities
     {
         /// <summary>
         /// Native methods necessary for manually loading and unloading a specific DISM API library.
@@ -73,41 +108,6 @@ namespace Microsoft.Dism
 
             [DllImport("kernel32.dll")]
             public static extern bool FreeLibrary(IntPtr hModule);
-        }
-
-        /// <summary>
-        /// Represents "generational" versions of Deployment Imaging and Servicing Management.
-        /// </summary>
-        public enum DismGeneration
-        {
-            /// <summary>
-            /// DISM libraries associated with WAIK and/or WADK were not found.
-            /// </summary>
-            NotFound = 0,
-
-            /// <summary>
-            /// DISM associated with the Windows 7 or Windows 7 Service Pack 1 version of the Windows Assessment and Installation Kit (WAIK).
-            /// With respect to Windows PE, this would be 3.0 (Windows 7) or 3.1 (Service Pack 1).
-            /// </summary>
-            Win7,
-
-            /// <summary>
-            /// DISM associated with the Windows 8 version of the Windows Assessment and Deployment Kit (WADK).
-            /// With respect to Windows PE, this would be 4.0 (Windows 8.0).
-            /// </summary>
-            Win8,
-
-            /// <summary>
-            /// DISM associated with the Windows 8.1 version of the Windows Assessment and Deployment Kit (WADK).
-            /// With respect to Windows PE, this would be 5.0 (Windows 8.1).
-            /// </summary>
-            Win8_1,
-
-            /// <summary>
-            /// DISM associated with the Windows 10 version of the Windows Assessment and Deployment Kit (WADK).
-            /// With respect to Windows PE, this would be 10.x (Windows 10.x).
-            /// </summary>
-            Win10
         }
 
         /// <summary>
@@ -205,24 +205,6 @@ namespace Microsoft.Dism
         }
 
         /// <summary>
-        /// Returns a DismGeneration enumeration indicating the latest DISM generation installed and available on the local system.
-        /// </summary>
-        /// <returns></returns>
-        public static DismGeneration GetLatestDismGeneration()
-        {
-            if (!String.IsNullOrEmpty(WADK10DISMAPIPath))
-                return DismGeneration.Win10;
-            else if (!String.IsNullOrEmpty(WADK81DISMAPIPath))
-                return DismGeneration.Win8_1;
-            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
-                return DismGeneration.Win8;
-            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
-                return DismGeneration.Win7;
-            else
-                return DismGeneration.NotFound;
-        }
-
-        /// <summary>
         /// Loads the DISM API library associated with the provided DismGeneration. 
         /// NOTE: This must be called before calling DismApi.Initialize(), as the initialization takes precedence based on Dynamic Link Library loading.
         /// If a DismGeneration library has already been loaded when initialize() is called, that version of the DISM generation library is utilized. If no DISM API library
@@ -264,10 +246,27 @@ namespace Microsoft.Dism
                 case DismGeneration.NotFound:
                 default:
                     return false;
-                    break;
             }
 
             return ((hDismApi = NativeMethods.LoadLibrary(dismApiPath)) != IntPtr.Zero ? true : false);
+        }
+
+        /// <summary>
+        /// Returns a DismGeneration enumeration indicating the latest DISM generation installed and available on the local system.
+        /// </summary>
+        /// <returns></returns>
+        public static DismGeneration GetLatestDismGeneration()
+        {
+            if (!String.IsNullOrEmpty(WADK10DISMAPIPath))
+                return DismGeneration.Win10;
+            else if (!String.IsNullOrEmpty(WADK81DISMAPIPath))
+                return DismGeneration.Win8_1;
+            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
+                return DismGeneration.Win8;
+            else if (!String.IsNullOrEmpty(WADK80DISMAPIPath))
+                return DismGeneration.Win7;
+            else
+                return DismGeneration.NotFound;
         }
 
         /// <summary>

--- a/src/Microsoft.Dism/Microsoft.Dism.csproj
+++ b/src/Microsoft.Dism/Microsoft.Dism.csproj
@@ -39,6 +39,7 @@
     <Compile Include="DismImageInfo.cs" />
     <Compile Include="DismMountedImageInfo.cs" />
     <Compile Include="DismPackage.cs" />
+    <Compile Include="DismUtilities.cs" />
     <Compile Include="DismWimCustomizedInfo.cs" />
     <Compile Include="DismApi.cs" />
     <Compile Include="ExtensionMethods.cs" />

--- a/src/Microsoft.Dism/Microsoft.Dism.csproj
+++ b/src/Microsoft.Dism/Microsoft.Dism.csproj
@@ -20,6 +20,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DismApiEx.cs" />
     <Compile Include="DismAppxPackage.cs" />
     <Compile Include="DismCapability.cs" />
     <Compile Include="DismCapabilityInfo.cs" />


### PR DESCRIPTION
Adds a "DismUtilities" class that adds support for external DISM libraries across DISM generations, which allows the user to (optionally) load external DISM libraries instead of defaulting to look for DISM on the local system.