### PR TITLE
Fix issue when unloading DismApi

### DIFF
--- a/src/Microsoft.Dism/DismUtilities.cs
+++ b/src/Microsoft.Dism/DismUtilities.cs
@@ -284,19 +284,12 @@ namespace Microsoft.Dism
         /// <summary>
         /// Unloads a previously-loaded DISM generation library.
         /// </summary>
-        /// <returns>
-        /// TRUE if successful, otherwise FALSE.
-        /// </returns>
-        public static bool UnloadDismGenerationLibrary()
+        public static void UnloadDismGenerationLibrary()
         {
-            if (_hDismApi != IntPtr.Zero)
+            if (_hDismApi != IntPtr.Zero && NativeMethods.FreeLibrary(_hDismApi))
             {
-                NativeMethods.FreeLibrary(_hDismApi);
-
                 _hDismApi = IntPtr.Zero;
             }
-
-            return _hDismApi == IntPtr.Zero;
         }
 
         /// <summary>

--- a/src/Microsoft.Dism/DismUtilities.cs
+++ b/src/Microsoft.Dism/DismUtilities.cs
@@ -292,6 +292,8 @@ namespace Microsoft.Dism
             if (_hDismApi != IntPtr.Zero)
             {
                 NativeMethods.FreeLibrary(_hDismApi);
+
+                _hDismApi = IntPtr.Zero;
             }
 
             return _hDismApi == IntPtr.Zero;

--- a/src/Microsoft.Dism/NativeMethods.cs
+++ b/src/Microsoft.Dism/NativeMethods.cs
@@ -38,15 +38,7 @@ namespace Microsoft.Dism
             /// </remarks>
             [DllImport(DismDllName, CharSet = DismCharacterSet)]
             [return: MarshalAs(UnmanagedType.Error)]
-            public static extern int DismAddCapability(
-                DismSession Session,
-                string Name,
-                [MarshalAs(UnmanagedType.Bool)] bool LimitAccess,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 6)] string[] SourcePaths,
-                UInt32 SourcePathCount,
-                SafeWaitHandle CancelEvent,
-                DismProgressCallback Progress,
-                IntPtr UserData);
+            public static extern int DismAddCapability(DismSession Session, string Name, [MarshalAs(UnmanagedType.Bool)] bool LimitAccess, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 6)] string[] SourcePaths, UInt32 SourcePathCount, SafeWaitHandle CancelEvent, DismProgressCallback Progress, IntPtr UserData);
 
             /// <summary>
             /// Adds a third party driver (.inf) to an offline Windows® image.


### PR DESCRIPTION
The code was not setting `_hDismApi` to `IntPtr.Zero` after calling `FreeLibrary` which would cause an exception on any subsequent calls to `InitializeEx()`