### PR TITLE
Automatically reload the session if necessary

### DIFF
--- a/src/Microsoft.Dism.Tests/DismExceptionTest.cs
+++ b/src/Microsoft.Dism.Tests/DismExceptionTest.cs
@@ -30,12 +30,6 @@ namespace Microsoft.Dism.Tests
         }
 
         [Fact]
-        public void DismReloadImageSessionRequiredExceptionTest()
-        {
-            VerifyDismException<DismReloadImageSessionRequiredException>(DismApi.DISMAPI_S_RELOAD_IMAGE_SESSION_REQUIRED, Resources.DismExceptionMessageReloadImageSessionRequired);
-        }
-
-        [Fact]
         public void GetLastErrorMessageTest()
         {
             const string message = "Hello World";

--- a/src/Microsoft.Dism/DismApi.cs
+++ b/src/Microsoft.Dism/DismApi.cs
@@ -1410,6 +1410,15 @@ namespace Microsoft.Dism
 #pragma warning restore SA1300 // Element must begin with upper-case letter
 
         /// <summary>
+        /// Throws an exception if the specified function fails.
+        /// </summary>
+        /// <param name="func">A <see cref="Func{Int32}"/> to execute and evaluate the return code of.</param>
+        internal static void ThrowIfFail(Func<int> func)
+        {
+            ThrowIfFail(func, DismApi.ERROR_SUCCESS);
+        }
+
+        /// <summary>
         /// Releases resources held by a structure or an array of structures returned by other DISM API functions.
         /// </summary>
         /// <param name="handle">A pointer to the structure, or array of structures, to be deleted. The structure must have been returned by an earlier call to a DISM API function.</param>
@@ -1417,15 +1426,6 @@ namespace Microsoft.Dism
         {
             // Call the native function
             NativeMethods.DismDelete(handle);
-        }
-
-        /// <summary>
-        /// Throws an exception if the specified function fails.
-        /// </summary>
-        /// <param name="func">A <see cref="Func{Int32}"/> to execute and evaluate the return code of.</param>
-        private static void ThrowIfFail(Func<int> func)
-        {
-            ThrowIfFail(func, DismApi.ERROR_SUCCESS);
         }
 
         /// <summary>
@@ -1629,11 +1629,7 @@ namespace Microsoft.Dism
         /// <exception cref="DismException">When a failure occurs.</exception>
         private static DismSession OpenSession(string imagePath, string windowsDirectory, string systemDrive)
         {
-            DismSession session = null;
-
-            ThrowIfFail(() => NativeMethods.DismOpenSession(imagePath, windowsDirectory, systemDrive, out session));
-
-            return session;
+            return new DismSession(imagePath, windowsDirectory, systemDrive);
         }
 
         /// <summary>

--- a/src/Microsoft.Dism/DismException.cs
+++ b/src/Microsoft.Dism/DismException.cs
@@ -45,9 +45,6 @@ namespace Microsoft.Dism
                 case DismApi.ERROR_SUCCESS_REBOOT_REQUIRED:
                     return new DismRebootRequiredException(errorCode);
 
-                case DismApi.DISMAPI_S_RELOAD_IMAGE_SESSION_REQUIRED:
-                    return new DismReloadImageSessionRequiredException(errorCode);
-
                 case DismApi.DISMAPI_E_DISMAPI_NOT_INITIALIZED:
                     // User has not called DismApi.Initialize()
                     return new DismNotInitializedException(errorCode);
@@ -116,22 +113,6 @@ namespace Microsoft.Dism
         /// <param name="errorCode">The error code to associate with the exception.</param>
         internal DismRebootRequiredException(int errorCode)
             : base(errorCode, Resources.DismExceptionMessageRebootRequired)
-        {
-        }
-    }
-
-    /// <summary>
-    /// The exception that is thrown when the previous operations requires a reload of image session.
-    /// </summary>
-    [Serializable]
-    public class DismReloadImageSessionRequiredException : DismException
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DismReloadImageSessionRequiredException"/> class.
-        /// </summary>
-        /// <param name="errorCode">The error code to associate with the exception.</param>
-        internal DismReloadImageSessionRequiredException(int errorCode)
-            : base(errorCode, Resources.DismExceptionMessageReloadImageSessionRequired)
         {
         }
     }

--- a/src/Microsoft.Dism/DismSession.cs
+++ b/src/Microsoft.Dism/DismSession.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Dism
 
             int hresult = DismApi.NativeMethods.DismOpenSession(_imagePath, _windowsDirectory, _systemDrive, out IntPtr sessionPtr);
 
-            DismApi.ThrowIfFail(() => hresult);
+            DismApi.ThrowIfFail(hresult);
 
             SetHandle(sessionPtr);
         }

--- a/src/Microsoft.Dism/DismSession.cs
+++ b/src/Microsoft.Dism/DismSession.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.Win32.SafeHandles;
+using System;
 using System.Runtime.ConstrainedExecution;
 
 namespace Microsoft.Dism
@@ -12,12 +13,41 @@ namespace Microsoft.Dism
     /// </summary>
     public sealed class DismSession : SafeHandleZeroOrMinusOneIsInvalid
     {
+        private readonly string _imagePath;
+        private readonly string _systemDrive;
+        private readonly string _windowsDirectory;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="DismSession"/> class.
         /// </summary>
-        public DismSession()
+        /// <param name="imagePath">An absolute or relative path to the root directory of an offline Windows image, an absolute or relative path to the root directory of a mounted Windows image, or DISM_ONLINE_IMAGE to associate with the online Windows installation.</param>
+        /// <param name="windowsDirectory">A relative or absolute path to the Windows directory. The path is relative to the mount point.</param>
+        /// <param name="systemDrive">The letter of the system drive that contains the boot manager. If SystemDrive is NULL, the default value of the drive containing the mount point is used.</param>
+        internal DismSession(string imagePath, string windowsDirectory, string systemDrive)
             : base(true)
         {
+            _imagePath = imagePath;
+            _windowsDirectory = windowsDirectory;
+            _systemDrive = systemDrive;
+
+            Reload();
+        }
+
+        /// <summary>
+        /// Reloads the session by closing the current session and opening it again.
+        /// </summary>
+        internal void Reload()
+        {
+            if (!IsInvalid)
+            {
+                DismApi.NativeMethods.DismCloseSession(handle);
+            }
+
+            int hresult = DismApi.NativeMethods.DismOpenSession(_imagePath, _windowsDirectory, _systemDrive, out IntPtr sessionPtr);
+
+            DismApi.ThrowIfFail(() => hresult);
+
+            SetHandle(sessionPtr);
         }
 
         /// <summary>

--- a/src/Microsoft.Dism/NativeMethods.cs
+++ b/src/Microsoft.Dism/NativeMethods.cs
@@ -501,7 +501,7 @@ namespace Microsoft.Dism
             [DllImport(DismDllName, CharSet = DismCharacterSet)]
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
             [return: MarshalAs(UnmanagedType.Error)]
-            public static extern int DismOpenSession(string ImagePath, string WindowsDirectory, string SystemDrive, out DismSession Session);
+            public static extern int DismOpenSession(string ImagePath, string WindowsDirectory, string SystemDrive, out IntPtr Session);
 
             /// <summary>
             /// Remounts a Windows image from the .wim or .vhd file that was previously mounted at the path specified by MountPath. Use the DismOpenSession Function to associate the image with a DISMSession after it is remounted.


### PR DESCRIPTION
* Modify DismSession to be reloadable
* Remove DismReloadImageSessionRequiredException

This lets callers keep the syntax:

```cs
using(DismSession = DismApi.OpenOnlineSession())
{
  ...
}
```

If an operation requires a reload, an exception is no longer thrown and instead the session is reloaded.