### PR TITLE
Add missing Regions field to DismAppxPackage_

### DIFF
--- a/src/Microsoft.Dism.Tests/GetProvisionedAppxPackagesTest.cs
+++ b/src/Microsoft.Dism.Tests/GetProvisionedAppxPackagesTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c). All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Shouldly;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.Dism.Tests
+{
+    public class GetProvisionedAppxPackagesTest : DismTestBase
+    {
+        public GetProvisionedAppxPackagesTest(TestWimTemplate template, ITestOutputHelper testOutput)
+            : base(template, testOutput)
+        {
+        }
+
+        [Fact]
+        public void GetProvisionedAppxPackagesSimple()
+        {
+            using (DismSession onlineSession = DismApi.OpenOnlineSession())
+            {
+                DismAppxPackageCollection packages = DismApi.GetProvisionedAppxPackages(onlineSession);
+
+                packages.ShouldNotBeNull();
+                packages.Count.ShouldBeGreaterThan(0);
+
+                foreach (DismAppxPackage package in packages)
+                {
+                    package.Architecture.ShouldNotBe(DismProcessorArchitecture.None);
+                    package.DisplayName.ShouldNotBeNullOrWhiteSpace();
+                    package.InstallLocation.ShouldNotBeNullOrWhiteSpace();
+                    package.PackageName.ShouldNotBeNullOrWhiteSpace();
+                    package.PublisherId.ShouldNotBeNullOrWhiteSpace();
+                    package.ResourceId.ShouldNotBeNullOrWhiteSpace();
+                    package.Version.ShouldBeGreaterThan(Version.Parse("0.0.0.0"));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.Dism.Tests/GetProvisionedAppxPackagesTest.cs
+++ b/src/Microsoft.Dism.Tests/GetProvisionedAppxPackagesTest.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Dism.Tests
                 DismAppxPackageCollection packages = DismApi.GetProvisionedAppxPackages(onlineSession);
 
                 packages.ShouldNotBeNull();
-                packages.Count.ShouldBeGreaterThan(0);
 
                 foreach (DismAppxPackage package in packages)
                 {

--- a/src/Microsoft.Dism/DismAppxPackage.cs
+++ b/src/Microsoft.Dism/DismAppxPackage.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Dism
             public string ResourceId;
             [MarshalAs(UnmanagedType.LPWStr)]
             public string InstallLocation;
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string Regions;
         }
 #pragma warning restore SA1600 // Elements must be documented
     }


### PR DESCRIPTION
This was causing fatal errors when marshalling the struct because the size was off.  Also added a unit test.

Fixes #58